### PR TITLE
Download only one ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Here is where I get my static binaries:
 ```json
 {
   "linux": {
-    "x64": "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz"
+    "ia32": "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz"
   },
 
   "darwin": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This has exactly the same interface as [node-fluent-ffmpeg](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg). It's a thin wrapper that includes binaries for mac, windows, and linux on 32 & 64 bit.
+This has exactly the same interface as [node-fluent-ffmpeg](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg). It's a thin wrapper that includes binaries for mac, windows, and linux.
 
 You can install it with `npm install easy-ffmpeg`
 
@@ -7,7 +7,6 @@ Here is where I get my static binaries:
 ```json
 {
   "linux": {
-    "ia32": "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz",
     "x64": "http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz"
   },
 

--- a/getbin.sh
+++ b/getbin.sh
@@ -5,12 +5,12 @@
 VERSION='2.8.2'
 
 rm -rf ffmpeg
-mkdir -p ffmpeg/linux/x64 ffmpeg/darwin/x64 ffmpeg/win32/ia32
+mkdir -p ffmpeg/linux/ia32 ffmpeg/darwin/x64 ffmpeg/win32/ia32
 
 cd ffmpeg/linux
-curl 'http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz' -o ffmpeg-64.tar.xz && 
-tar xf ffmpeg-64.tar.xz && 
-mv ffmpeg-*-64bit-static/ffmpeg ffmpeg-*-64bit-static/ffprobe x64
+curl 'http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz' -o ffmpeg-32.tar.xz && 
+tar xf ffmpeg-32.tar.xz && 
+mv ffmpeg-*-32bit-static/ffmpeg ffmpeg-*-32bit-static/ffprobe ia32
 rm -rf ffmpeg-*-*-static *.tar.xz
 
 cd ../darwin

--- a/getbin.sh
+++ b/getbin.sh
@@ -5,12 +5,9 @@
 VERSION='2.8.2'
 
 rm -rf ffmpeg
-mkdir -p ffmpeg/linux/ia32 ffmpeg/linux/x64 ffmpeg/darwin/x64 ffmpeg/win32/ia32
+mkdir -p ffmpeg/linux/x64 ffmpeg/darwin/x64 ffmpeg/win32/ia32
 
 cd ffmpeg/linux
-curl 'http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz' -o ffmpeg-32.tar.xz && 
-tar xf ffmpeg-32.tar.xz && 
-mv ffmpeg-*-32bit-static/ffmpeg ffmpeg-*-32bit-static/ffprobe ia32
 curl 'http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz' -o ffmpeg-64.tar.xz && 
 tar xf ffmpeg-64.tar.xz && 
 mv ffmpeg-*-64bit-static/ffmpeg ffmpeg-*-64bit-static/ffprobe x64

--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ var arch = process.platform == 'darwin' ? 'x64' : 'ia32';
 var ext = process.platform == 'win32' ? '.exe' : '';
 
 FfmpegCommand.setFfmpegPath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffmpeg' + ext) )
+FfmpegCommand.setFfprobePath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffprobe' + ext) )
 
 module.exports = FfmpegCommand;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 var FfmpegCommand = require('fluent-ffmpeg')
 var path = require('path')
 
-var p = path.join(__dirname, 'ffmpeg', process.platform, arch, 'ffmpeg')
+// windows: 32bit / other: x64
+var arch = process.platform == 'win32' ? 'ia32' : 'x64';
 
-// only one platform  available, but works for both
-var arch = process.arch
-if (process.platform === 'win32') {
-  arch = 'ia32'
-  p += '.exe'
-}
+// only windows has an extension
+var ext = process.platform == 'win32' ? '.exe' : '';
 
-FfmpegCommand.setFfmpegPath(p)
-module.exports = FfmpegCommand
+FfmpegCommand.setFfmpegPath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffmpeg' + ext) )
+
+module.exports = FfmpegCommand;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var FfmpegCommand = require('fluent-ffmpeg')
 var path = require('path')
 
-// windows: 32bit / other: x64
-var arch = process.platform == 'win32' ? 'ia32' : 'x64';
+// osx: x64 / other: ia32
+var arch = process.platform == 'darwin' ? 'x64' : 'ia32';
 
 // only windows has an extension
 var ext = process.platform == 'win32' ? '.exe' : '';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-var FfmpegCommand = require('fluent-ffmpeg')
-var path = require('path')
+var FfmpegCommand = require('fluent-ffmpeg'),
+    path = require('path'),
+    fs = require('fs');
 
 // osx: x64 / other: ia32
 var arch = process.platform == 'darwin' ? 'x64' : 'ia32';
@@ -7,7 +8,19 @@ var arch = process.platform == 'darwin' ? 'x64' : 'ia32';
 // only windows has an extension
 var ext = process.platform == 'win32' ? '.exe' : '';
 
-FfmpegCommand.setFfmpegPath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffmpeg' + ext) )
-FfmpegCommand.setFfprobePath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffprobe' + ext) )
+try {
+
+    // this checks if the ffmpeg folder exists in our repo, if it doesn't it will return an error
+    fs.accessSync( path.join(__dirname, 'ffmpeg-' + process.platform) , fs.F_OK);
+
+    // folder exists so we need to load ffmpeg and ffprobe from our repo
+    FfmpegCommand.setFfmpegPath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffmpeg' + ext) )
+    FfmpegCommand.setFfprobePath( path.join(__dirname, 'ffmpeg-' + process.platform, arch, 'ffprobe' + ext) )
+
+} catch (e) {
+    // folder does not exist, this means that ffmpeg and ffprobe
+    // wore found somewhere else during the install process
+    // fluent-ffmpeg will set the correct paths on it's own
+}
 
 module.exports = FfmpegCommand;

--- a/install.js
+++ b/install.js
@@ -10,21 +10,47 @@ var tarball = require('tarball-extract'),
 var user = 'jaruba',
     tag = 'v0.0.1',
     repoName = 'ffmpeg-binaries',
-    package = 'ffmpeg-' + process.platform + '.tgz';
+    package = 'ffmpeg-' + process.platform + '.tgz',
+    counter = 0,
+    errors = 0;
 
-var url = 'https://github.com/' + user + '/' + repoName + '/releases/download/' + tag + '/' + package;
+function downloader() {
+    // if no ffmpeg and ffprobe are found installed
+    // we will download the one for our platform
 
-request
-  .get(url)
-  .on('error', function (err) {
-    throw err
-  })
-  .pipe(fs.createWriteStream( package ))
-  .on('close', function () {
-    tarball.extractTarball(package, __dirname, function (err, result) {
-      if (err) throw err
-      fs.unlink(package, function (err) {
-        if (err) throw err
+    var url = 'https://github.com/' + user + '/' + repoName + '/releases/download/' + tag + '/' + package;
+
+    request
+      .get(url)
+      .on('error', function (err) {
+        throw err
       })
-    })
-  })
+      .pipe(fs.createWriteStream( package ))
+      .on('close', function () {
+        tarball.extractTarball(package, __dirname, function (err, result) {
+          if (err) throw err
+          fs.unlink(package, function (err) {
+            if (err) throw err
+          })
+        })
+      })
+}
+
+function checker(err, path) {
+    if (err) errors++;
+    else if (!err && !path) errors++;
+
+    if (counter) {
+        // finished checking for ffmpeg and ffprobe
+        if (errors) {
+            // could not find ffmpeg and ffprobe installed, downloading
+            downloader();
+        }
+    } else counter++;
+}
+
+// let's try to find ffmpeg and ffprobe
+var ffmpeg = require('fluent-ffmpeg')();
+
+ffmpeg._getFfmpegPath(checker);
+ffmpeg._getFfprobePath(checker);

--- a/install.js
+++ b/install.js
@@ -10,7 +10,7 @@ var tarball = require('tarball-extract'),
 var user = 'jaruba',
     tag = 'v0.0.1',
     repoName = 'ffmpeg-binaries',
-    package = 'ffmpeg' + process.platform + '.tgz';
+    package = 'ffmpeg-' + process.platform + '.tgz';
 
 var url = 'https://github.com/' + user + '/' + repoName + '/releases/download/' + tag + '/' + package;
 

--- a/install.js
+++ b/install.js
@@ -1,17 +1,29 @@
-var tarball = require('tarball-extract')
-var request = require('request')
-var fs = require('fs')
+var tarball = require('tarball-extract'),
+    request = require('request'),
+    fs = require('fs');
+
+// in your case it should be:
+// var user = 'konsumer';
+// var tag = '0.0.8'
+// var repoName = 'easy-ffmpeg';
+
+var user = 'jaruba',
+    tag = 'v0.0.1',
+    repoName = 'ffmpeg-binaries',
+    package = 'ffmpeg' + process.platform + '.tgz';
+
+var url = 'https://github.com/' + user + '/' + repoName + '/releases/download/' + tag + '/' + package;
 
 request
-  .get('https://github.com/konsumer/easy-ffmpeg/releases/download/0.0.8/ffmpeg.tgz')
+  .get(url)
   .on('error', function (err) {
     throw err
   })
-  .pipe(fs.createWriteStream('ffmpeg.tgz'))
+  .pipe(fs.createWriteStream( package ))
   .on('close', function () {
-    tarball.extractTarball('ffmpeg.tgz', __dirname, function (err, result) {
+    tarball.extractTarball(package, __dirname, function (err, result) {
       if (err) throw err
-      fs.unlink('ffmpeg.tgz', function (err) {
+      fs.unlink(package, function (err) {
         if (err) throw err
       })
     })


### PR DESCRIPTION
- removed 32bit binaries for Linux (who even uses 32bit Linux anymore?)
- split `ffmpeg.tgz` into: `ffmpeg-linux.tgz`, `ffmpeg-darwin.tgz`, `ffmpeg-win32.tgz`
- now downloads only the `ffmpeg` binary for your platform

It's currently hooked up to a repo where I released the 3 separate archives, if you choose to accept this PR you should change the info accordingly to download from your repo. (check comments from `install.js`)

As a side note, I saw your using `.setFfmpegPath()`, is `setFfprobePath()` not required? Does it check for it in the same folder as `ffmpeg` anyway?
